### PR TITLE
adding new sample apis and removing csrf check 

### DIFF
--- a/todo_backend/todo/urls.py
+++ b/todo_backend/todo/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
-from .views import GenerateTextView, TaskListCreate, TaskDetail
+from .views import GenerateTextView, TaskListCreate, TaskDetail, EchoView,NextTaskView
 
 urlpatterns = [
     path('generate-text/', GenerateTextView.as_view(), name='generate-text'),
     path('tasks/', TaskListCreate.as_view(), name='task-list-create'),
     path('tasks/<int:pk>/', TaskDetail.as_view(), name='task-detail'),
+    path('echo/', EchoView.as_view(), name='echo'),
+    path('next-task/', NextTaskView.as_view(), name='next-task'),
 ]

--- a/todo_backend/todo/views.py
+++ b/todo_backend/todo/views.py
@@ -24,3 +24,28 @@ class GenerateTextView(views.APIView):
         
         generated_text = generate_text(prompt)
         return Response({"data": generated_text}, status=status.HTTP_200_OK)
+
+# View which echoes back the input.
+# This api does not interact with the database but merely returns a
+# response based on the input
+class EchoView(views.APIView):
+    def post(self, request, *args, **kwargs):
+        prompt = request.data.get('prompt')
+        if not prompt:
+            return Response({"error": "Prompt is required"}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"echo":prompt}, status=status.HTTP_200_OK)
+    
+# View which retrieves a task that has the completed field = false.
+# Uses the Django database library to interact with the database.
+# See https://docs.djangoproject.com/en/5.0/topics/db/queries/
+#   for more examples on making database calls
+class NextTaskView(views.APIView):
+    def get(self, request, *args, **kwargs):
+        incompleteTasks = Task.objects.filter(completed = False)
+        if len(incompleteTasks) == 0:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        aTask = incompleteTasks[0]
+        # once we have a model object, use the appropriate serializer
+        # to serialize the response
+        serializer = TaskSerializer(aTask)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/todo_backend/todo_project/auth.py
+++ b/todo_backend/todo_project/auth.py
@@ -1,6 +1,0 @@
-from rest_framework import authentication 
-
-class CsrfExemptSessionAuthentication(authentication.SessionAuthentication):
-
-    def enforce_csrf(self, request):
-        return  # To not perform the csrf check previously happening

--- a/todo_backend/todo_project/auth.py
+++ b/todo_backend/todo_project/auth.py
@@ -1,0 +1,6 @@
+from rest_framework import authentication 
+
+class CsrfExemptSessionAuthentication(authentication.SessionAuthentication):
+
+    def enforce_csrf(self, request):
+        return  # To not perform the csrf check previously happening

--- a/todo_backend/todo_project/settings.py
+++ b/todo_backend/todo_project/settings.py
@@ -11,8 +11,19 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 from pathlib import Path
-
 import os 
+
+from rest_framework import authentication 
+
+# custom authentication class to bypass csrf checks
+# The csrf check causes csrf missing errors when the react frontend was running
+# in the same browser session as the django backend, and a user was
+# logged into the django backend (for django admin)
+class CsrfExemptSessionAuthentication(authentication.SessionAuthentication):
+
+    def enforce_csrf(self, request):
+        return  # To not perform the csrf check previously happening
+
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -49,7 +60,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+#    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -105,6 +116,10 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': ['todo_project.auth.CsrfExemptSessionAuthentication',
+                                       'rest_framework.authentication.BasicAuthentication'],
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/4.2/topics/i18n/

--- a/todo_backend/todo_project/settings.py
+++ b/todo_backend/todo_project/settings.py
@@ -117,7 +117,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': ['todo_project.auth.CsrfExemptSessionAuthentication',
+    'DEFAULT_AUTHENTICATION_CLASSES': ['todo_project.settings.CsrfExemptSessionAuthentication',
                                        'rest_framework.authentication.BasicAuthentication'],
 }
 


### PR DESCRIPTION
Added 2 new apis as samples for students.
POST /echo/ is a sample of an api which does not use the db.
GET /next-task/ is a sample of an api which uses the django database module to call the database (versus the standard django rest framework method of just specifying a queryset and serializer)

I believe these 2 samples will be helpful building blocks to building an ai enabled feature.

Also removed the standard csrf check which occurs when a user is logged into django.  This causes problems for the react frontend if the same browser is used for the react frontend and for django admin, as django detects the session cookie from the react frontend and then tries to checks the csrf token, which is missing.