### PR TITLE
regenerate Pipfile.lock.  

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -66,12 +66,12 @@
         },
         "django": {
             "hashes": [
-                "sha256:848a5980e8efb76eea70872fb0e4bc5e371619c70fffbe48e3e1b50b2c09455d",
-                "sha256:d3b811bf5371a26def053d7ee42a9df1267ef7622323fe70a601936725aa4557"
+                "sha256:61ee4a130efb8c451ef3467c67ca99fdce400fedd768634efc86a68c18d80d30",
+                "sha256:c77f926b81129493961e19c0e02188f8d07c112a1162df69bfab178ae447f94a"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.10'",
-            "version": "==5.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.15"
         },
         "django-cors-headers": {
             "hashes": [
@@ -90,6 +90,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==3.15.2"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.2"
         },
         "h11": {
             "hashes": [
@@ -192,12 +200,12 @@
         },
         "openai": {
             "hashes": [
-                "sha256:e6b9431cefacfbc88fe630b4b42d7a0876ac1203fdfbf61d31d0c10273219622",
-                "sha256:f29b00250483883c0a1abfb2710b1eed25321ceb04a73a6792c9784bb7365799"
+                "sha256:26b81f39b49dce92ff5d30c373625ddb212c2f1050e1574e456d18423730cdd0",
+                "sha256:3b6cca4571667f3e0800442ef8f2bfa6a6f3301c51776bc7626159a4d81c242c"
             ],
             "index": "pypi",
             "markers": "python_full_version >= '3.7.1'",
-            "version": "==1.40.7"
+            "version": "==1.41.0"
         },
         "pydantic": {
             "hashes": [


### PR DESCRIPTION
The old version had a "marker" for python >= 3.10 for the django install - so was ignoring installing django.  This was introduced when i added tzdata.
After removing pipfile.lock and regenerating with pipenv install, the marker  for 3.10 was changed to 3.8.